### PR TITLE
ci(codeql): default security queries only (drop +security-and-quality noise)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
-          queries: +security-and-quality
+          # Default security queries only; code-quality linting is handled by ruff (see ci.yml).
       - uses: github/codeql-action/analyze@v3
         with:
           category: /language:${{ matrix.language }}


### PR DESCRIPTION
Drops `queries: +security-and-quality` from the CodeQL workflow so it runs only the default **security** suite.

The quality suite was surfacing 84 code-quality items (commented-out code, unused/uninitialized locals, unreachable statements) as PR-blocking "alerts" with **no security severity** — code quality is already enforced by ruff in `ci.yml`.

Investigated the `py/uninitialized-local-variable` alerts (`ray_evaluation.py`, `run_jobs_ray_tune.py`): all are the "variable assigned only inside if/elif branches" defensive pattern with no reachable unbound path on real inputs — not active bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)